### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ These steps are done only once.  In subsequent usage, there is no need to go thr
 Install latest version of [Go](https://golang.org/dl/). Run these on the command line inside `src` folder.
 * go mod init GEM
 * go mod tidy
+* go mod vendor
 
 ##### Install MySQL Server
 The current version of Codespace need MySQL server pre-installed and running beforehand. The MySQL server can be installed using the following resources.

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The current version of Codespace need MySQL server pre-installed and running bef
 ##### Create New MySQL User and Grant Previlege
 Enter into MySQL CLI using the following command
 ```
-myql -u root -p
+mysql -u root -p
 ```
 Update SQL mode (needs to avoid conflict with Go library).
 ```


### PR DESCRIPTION
Fixed a typo in the README file. Changed 'myql' to 'mysql' in the command for entering MySQL CLI under the 'Create New MySQL User and Grant Privilege' section.